### PR TITLE
Fix: Ensure carry tensors are created on the correct device

### DIFF
--- a/models/recursive_reasoning/trm.py
+++ b/models/recursive_reasoning/trm.py
@@ -182,11 +182,12 @@ class TinyRecursiveReasoningModel_ACTV1_Inner(nn.Module):
         return self.embed_scale * embedding
 
     def empty_carry(self, batch_size: int):
+        device = self.lm_head.weight.device 
         return TinyRecursiveReasoningModel_ACTV1InnerCarry(
-            z_H=torch.empty(batch_size, self.config.seq_len + self.puzzle_emb_len, self.config.hidden_size, dtype=self.forward_dtype),
-            z_L=torch.empty(batch_size, self.config.seq_len + self.puzzle_emb_len, self.config.hidden_size, dtype=self.forward_dtype),
+            z_H=torch.empty(batch_size, self.config.seq_len + self.config.puzzle_emb_len, self.config.hidden_size, dtype=self.forward_dtype, device=device),
+            z_L=torch.empty(batch_size, self.config.seq_len + self.config.puzzle_emb_len, self.config.hidden_size, dtype=self.forward_dtype, device=device),
         )
-        
+            
     def reset_carry(self, reset_flag: torch.Tensor, carry: TinyRecursiveReasoningModel_ACTV1InnerCarry):
         return TinyRecursiveReasoningModel_ACTV1InnerCarry(
             z_H=torch.where(reset_flag.view(-1, 1, 1), self.H_init, carry.z_H),


### PR DESCRIPTION
**PR Description:**
Fixes a `RuntimeError` caused by a device mismatch when running the model on a GPU.

The `empty_carry` function was creating tensors on the CPU by default. This change ensures they are created on the same device as the model's parameters, making it compatible with GPU usage.