### PR TITLE
Improving results by multiple supervision steps before grad update

### DIFF
--- a/config/cfg_pretrain.yaml
+++ b/config/cfg_pretrain.yaml
@@ -24,6 +24,7 @@ checkpoint_every_eval: True
 lr: 1e-4
 lr_min_ratio: 1.0
 lr_warmup_steps: 2000
+num_steps_for_grad: 1
 
 # Standard hyperparameter settings for LM, as used in Llama
 beta1: 0.9


### PR DESCRIPTION
Adding support for performing multiple backward passes to accumulate gradients from different `N_supervision` steps. This allows to introduce another source of stochasticity in the parameter update. A value of $2$ already seems to give an improvement. (I think $2$ passes are already enough since it can happen that the first pass got halted and the second pass then got a new data sample to compute gradients on). Results on sudoko are as follows

| Experiment name              | Num Training iterations | All.Exact_Accuracy |
|------------------------------|--------------------------|--------------------|
| pretrain_mlp_t_sudoku        | 39060                    | 0.64925            |
| pretrain_mlp_t_sudoku_2_grads| 39060                    | **0.87908**            |


I do not unfortunately have compute resources to check this thoroughly on all datasets. Would be great if anyone can check. Thanks. 