### PR TITLE
Docs: Add README to evaluators/ explaining missing sudoku.py

### DIFF
--- a/evaluators/README.md
+++ b/evaluators/README.md
@@ -1,0 +1,8 @@
+### Missing Sudoku Evaluator
+
+This directory is missing the `sudoku.py` evaluator script.
+
+The official `pretrain.py` script fails to evaluate the `trm_sudoku.pt` model because it cannot find an evaluator named "sudoku". The log shows a `No evaluator found` warning, and the script exits without printing an accuracy score.
+
+This makes it impossible to reproduce the paper's Sudoku evaluation results with the provided code.
+


### PR DESCRIPTION
Adds a README.md to the evaluators/ folder to document the missing sudoku.py script. This makes it clear to other developers why they can't reproduce the Sudoku evaluation.